### PR TITLE
Bugfixes, updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The following is a list of the environment variables:
     > What port you want the service to run on, defaults to 3000.
 
 
+###### Preparing for dependencies:
+```
+npm install
+```
+This will download  all the required dependencies for the project so that npm start/npm test will work.
+
 ###### Running the service:
 ```
 npm start

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# MyGovBC-CAPTCHA-Service
-A microservice for CAPTCHA
+# MyGovBC-CAPTCHA
+
+#### A CAPTCHA microservice
+
+This project contains a microservice to enable you to easily include a CAPTCHA widget in my online digital form to protect your digital service from bots.
+
+###### Git Checkout and initialization:
+```
+git clone git@github.com:bcgov/MyGovBC-CAPTCHA-Service.git
+cd MyGovBC-CAPTCHA-Service/
+```
+
+You have two choices of configuring the service
+1. add some environment variables
+2. open server.js and change the default strings.
+
+The following is a list of the environment variables:
+
+* SECRET
+    > This should be the same on each server/service/pod that will need to verify the JWT created by any other server/service/pod.
+* SALT
+    > This is for encrypting the answer in the captcha for stateless verification on any other server/service/pod.
+* PRIVATE_KEY
+    > (Not used) Placeholder for default encryption cipher used internally to the microservice.
+* LOG_LEVEL
+    > Set this to none/error/debug depending on how much verbosity to stderr/stdout you would like.
+* SERVICE_PORT
+    > What port you want the service to run on, defaults to 3000.
+
+
+###### Running the service:
+```
+npm start
+```
+
+###### Running the unit tests locally:
+```
+npm test
+```
+
+The tests cover the following cases:
+1. Empty request on requesting a captcha (must fail)
+2. Passing in a nonce for generating the captcha (must pass and return valid captcha
+3. If either the captcha failed to generate, or the encrypted password sent with the request fails, the unit test will fail. (must pass)
+4. The captcha is written to disk, and the default browser is used to open the captcha for viewing, the user must then input the correct captcha, or the test will fail (must pass)
+5. Verifying the captcha (must pass)
+6. Receiving and then sending back the signed JWT (must pass)
+
+
+###### API Specification:
+Request Type | API Endpoint | Parameters | Purpose
+------------ | ------------- | ------------- | -------------
+HTTP POST | /captcha | request body: { nonce: "string" } | Retrieve a captcha to be displayed to a user
+HTTP POST | /verify/captcha | request body: { nonce: "string", answer: "string", encryptedAnswer: "string" } | Compare the answer to the encryptedAnswer, return a signed JWT if successful
+HTTP POST | /verify/jwt | request body: { nonce: "string", token: "jwt token" } | Validate a signed JWT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mygovbc-captcha-widget",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A reusable, secure and reliable CAPTCHA microservice for service providers to use within online digital services.",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "crypto": "0.0.3",
     "express": "^4.14.1",
     "jsonwebtoken": "^7.2.1",
+    "open": "0.0.5",
     "svg-captcha": "^1.3.1"
   },
   "repository": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,15 +1,24 @@
 /*jshint node:true, esversion: 6 */
 'use strict';
 
-var service = require ('mygovbc-captcha-widget');
-var jwt = require('jsonwebtoken');
-var crypto = require('crypto');
-var open = require('open');
-var path = require('path').basename(__dirname);
+var service 	= require ('mygovbc-captcha-widget');
+var jwt 		= require('jsonwebtoken');
+var crypto 		= require('crypto');
+var open 		= require('open');
+var path 		= require('path').basename(__dirname);
 
-var resourceID = crypto.randomBytes(64).toString('hex');
+var resourceID 	= crypto.randomBytes(64).toString('hex');
+
+// Fail because no nonce passed in.
+var t2 = service.getCaptcha({});
+if (t2 && !t2.valid) {
+	console.log("unit test success.");
+} else {
+	console.log("unit test failed.");
+	process.exit(1);
+}
+
 var c = service.getCaptcha({nonce: resourceID});
-
 if (!c.captcha) {
 	console.log("Captcha was not generated.");
 	process.exit(1);
@@ -18,17 +27,23 @@ if (!c.validation) {
 	console.log("Encrypted answer not found.");
 	process.exit(1);
 }
-// console.log("validation:", c.validation);
 
+// Success on normal case
+if (c.captcha) {
+	console.log("unit test success.");
+} else {
+	console.log("unit test failed.");
+	process.exit(1);
+}
 var fs = require('fs');
-fs.writeFile(__dirname + "/test.html", c.captcha, function(err) {
-	if(err) {
-		console.log("could not write to filesystem:", err);
-		process.exit(1);
-	}
-	// console.log("The file was saved!", __dirname);
+fs.writeFileSync(__dirname + "/test.html", c.captcha);
+
+var os = require('os');
+if (os.platform() === 'win32') {
 	open("file:///" + __dirname + "\\" + "test.html");
-});
+} else {
+	open(__dirname + "/" + "test.html");
+}
 
 const readline = require('readline');
 


### PR DESCRIPTION
Adding a package dependency 'open' solely for unit tests - it is not required for the general use of the microservice.

Documentation covers how to pull, initialize, configure and run the microservice, as well as explains the unit tests and API specification.

Since the npm isn't available on npmjs.org (yet), installation will require "npm link mygovbc-captcha-widget" before running npm start/npm test commands.